### PR TITLE
Add Scala 2.13 compilation; update all dependencies

### DIFF
--- a/akka-actor-thread-context/build.sbt
+++ b/akka-actor-thread-context/build.sbt
@@ -1,4 +1,5 @@
 libraryDependencies ++= Seq(
-  "com.typesafe.akka" %% "akka-actor" % "2.4.16",
-  "com.lucidchart" % "thread-context" % "0.6"
+  // Note: Akka 2.6.x is not compiled for Scala 2.11.x
+  "com.typesafe.akka" %% "akka-actor" % "2.5.31",
+  "com.lucidchart" % "thread-context" % "0.7"
 )

--- a/akka-actor-thread-context/src/main/scala-2.13/com/lucidchart/akka/threadcontext/DispatcherConfigurator.scala
+++ b/akka-actor-thread-context/src/main/scala-2.13/com/lucidchart/akka/threadcontext/DispatcherConfigurator.scala
@@ -1,0 +1,24 @@
+package com.lucidchart.akka.threadcontext
+
+import akka.dispatch.{Dispatcher, DispatcherPrerequisites, MessageDispatcherConfigurator}
+import com.github.threadcontext.Context
+import com.typesafe.config.Config
+import java.util.concurrent.TimeUnit
+import java.util.function.Supplier
+import scala.concurrent.duration.DurationLong
+
+class DispatcherConfigurator(config: Config, prerequisites: DispatcherPrerequisites, contextSupplier: Supplier[Context]) extends MessageDispatcherConfigurator(config, prerequisites) {
+  override val dispatcher = new Dispatcher(
+    this,
+    config.getString("id"),
+    config.getInt("throughput"),
+    config.getDuration("throughput-deadline-time", TimeUnit.NANOSECONDS).nanos,
+    configureExecutor(),
+    config.getDuration("shutdown-timeout", TimeUnit.MILLISECONDS).millis
+  ) { dispatcher =>
+    override def execute(runnable: Runnable) = {
+      val context = contextSupplier.get()
+      super.execute(() => context.run(runnable))
+    }
+  }
+}

--- a/build.sbt
+++ b/build.sbt
@@ -1,7 +1,8 @@
 lazy val `akka-actor-thread-context` = project.cross
 
-lazy val `akka-actor-thread-context_2.11` = `akka-actor-thread-context`("2.11.8")
-lazy val `akka-actor-thread-context_2.12` = `akka-actor-thread-context`("2.12.1")
+lazy val `akka-actor-thread-context_2.11` = `akka-actor-thread-context`("2.11.12")
+lazy val `akka-actor-thread-context_2.12` = `akka-actor-thread-context`("2.12.11")
+lazy val `akka-actor-thread-context_2.13` = `akka-actor-thread-context`("2.13.2")
 
 inScope(Global)(Seq(
   credentials += Credentials("Sonatype Nexus Repository Manager", "oss.sonatype.org", sys.env.getOrElse("SONATYPE_USERNAME", ""), sys.env.getOrElse("SONATYPE_PASSWORD", "")),
@@ -13,7 +14,7 @@ inScope(Global)(Seq(
   organizationName := "Lucid Software",
   PgpKeys.pgpPassphrase := Some(Array.emptyCharArray),
   resolvers += Resolver.typesafeRepo("releases"),
-  scalaVersion := "2.11.8",
+  scalaVersion := "2.13.2",
   scmInfo := Some(ScmInfo(
     url("https://github.com/lucidsoftware/akka-thread-context"),
     "scm:git:git@github.com:lucidsoftware/akka-thread-context.git"

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=0.13.13
+sbt.version=1.3.12

--- a/project/build.sbt
+++ b/project/build.sbt
@@ -1,5 +1,5 @@
-addSbtPlugin("com.jsuereth" % "sbt-pgp" % "1.0.0")
+addSbtPlugin("com.jsuereth" % "sbt-pgp" % "2.0.1")
 
-addSbtPlugin("com.lucidchart" % "sbt-cross" % "3.1")
+addSbtPlugin("com.lucidchart" % "sbt-cross" % "4.0")
 
-addSbtPlugin("org.xerial.sbt" % "sbt-sonatype" % "1.1")
+addSbtPlugin("org.xerial.sbt" % "sbt-sonatype" % "3.9.2")


### PR DESCRIPTION
This adds support for compiling to Scala 2.13.
I also updated all the dependencies, as some needed to be newer in order to have their own Scala 2.13 support.