### PR TITLE
Update to Akka 2.6; drop Scala 2.11 support

### DIFF
--- a/akka-actor-thread-context/build.sbt
+++ b/akka-actor-thread-context/build.sbt
@@ -1,5 +1,4 @@
 libraryDependencies ++= Seq(
-  // Note: Akka 2.6.x is not compiled for Scala 2.11.x
-  "com.typesafe.akka" %% "akka-actor" % "2.5.31",
+  "com.typesafe.akka" %% "akka-actor" % "2.6.15",
   "com.lucidchart" % "thread-context" % "0.7"
 )

--- a/build.sbt
+++ b/build.sbt
@@ -2,9 +2,8 @@ lazy val `akka-actor-thread-context` = project.cross
 
 lazy val commonSettings = Seq(publishTo := sonatypePublishToBundle.value)
 
-lazy val `akka-actor-thread-context_2.11` = `akka-actor-thread-context`("2.11.12").settings(commonSettings)
-lazy val `akka-actor-thread-context_2.12` = `akka-actor-thread-context`("2.12.11").settings(commonSettings)
-lazy val `akka-actor-thread-context_2.13` = `akka-actor-thread-context`("2.13.2").settings(commonSettings)
+lazy val `akka-actor-thread-context_2.12` = `akka-actor-thread-context`("2.12.14").settings(commonSettings)
+lazy val `akka-actor-thread-context_2.13` = `akka-actor-thread-context`("2.13.6").settings(commonSettings)
 
 inScope(Global)(Seq(
   credentials += Credentials("Sonatype Nexus Repository Manager", "oss.sonatype.org", sys.env.getOrElse("SONATYPE_USERNAME", ""), sys.env.getOrElse("SONATYPE_PASSWORD", "")),
@@ -16,7 +15,7 @@ inScope(Global)(Seq(
   organizationName := "Lucid Software",
   PgpKeys.pgpPassphrase := Some(Array.emptyCharArray),
   resolvers += Resolver.typesafeRepo("releases"),
-  scalaVersion := "2.13.2",
+  scalaVersion := "2.13.6",
   scmInfo := Some(ScmInfo(
     url("https://github.com/lucidsoftware/akka-thread-context"),
     "scm:git:git@github.com:lucidsoftware/akka-thread-context.git"

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.3.12
+sbt.version=1.5.4


### PR DESCRIPTION
Hello,
This PR updates the Akka version to 2.6, which has been the stable Akka for some time now.
This required dropping support for Scala 2.11, however, as Akka no longer publishes version for that.

I'm not sure if you'll want to accept this change, or not - but I thought I'd offer it you.

It's my feeling that supporting the  current stable Akka version is more useful than supporting a very old version of Scala - but I don't know what your primary users are actually using..